### PR TITLE
fix: Immediately skip non-X25519 stanzas

### DIFF
--- a/cmd/age-plugin-tkey/runidentity.go
+++ b/cmd/age-plugin-tkey/runidentity.go
@@ -64,6 +64,14 @@ func runIdentity() error {
 			rawIdentities = append(rawIdentities, rawID)
 
 		case "recipient-stanza":
+			if len(s.args) == 0 {
+				return fmt.Errorf("empty recipient-stanza: %q", s)
+			}
+			typ := s.args[1]
+			if typ != "X25519" {
+				le.Printf("recipient skipped: type is %s, expected X25519\n", typ)
+				continue
+			}
 			if len(s.args) != 3 || len(s.data) == 0 {
 				return fmt.Errorf("malformed recipient-stanza: %q", s)
 			}
@@ -72,11 +80,7 @@ func runIdentity() error {
 			if err != nil {
 				return fmt.Errorf("bad recipient-stanza file_index: %w", err)
 			}
-			typ, pubKeyStr := s.args[1], s.args[2]
-			if typ != "X25519" {
-				le.Printf("recipient skipped: type is %s, expected X25519\n", typ)
-				continue
-			}
+			pubKeyStr := s.args[2]
 
 			// gentle reminder: this pubkey is the ephemeral session
 			// key, not recipient pubkey for sender's identity


### PR DESCRIPTION
Checking the stanza type first avoids a problem with non-X25519 stanzas that may not have a length of exactly 3 fields. An example of such a stanza is piv-p256 which is used by the age-plugin-yubikey. It has 4 fields.

Fixes #5.